### PR TITLE
Make arguments to OpenMC surface classes lowercase

### DIFF
--- a/models/openmc/beavrs/assemblies.py
+++ b/models/openmc/beavrs/assemblies.py
@@ -50,7 +50,7 @@ class Assemblies(object):
 
         # Rectangular prism around the edge of the pinlattice
         self.lattice_surfs = \
-            openmc.get_rectangular_prism(17*c.pinPitch, 17*c.pinPitch)
+            openmc.rectangular_prism(17*c.pinPitch, 17*c.pinPitch)
 
 
     def _add_assembly_surfs(self):
@@ -58,7 +58,7 @@ class Assemblies(object):
 
         # Rectangular prism around the edge of the pinlattice
         self.assem_surfs = \
-            openmc.get_rectangular_prism(c.latticePitch, c.latticePitch)
+            openmc.rectangular_prism(c.latticePitch, c.latticePitch)
 
 
     def _add_bpra_layouts(self):

--- a/models/openmc/beavrs/baffle.py
+++ b/models/openmc/beavrs/baffle.py
@@ -26,7 +26,7 @@ class Baffle(object):
     def _add_baffle_universes(self):
         """ Adds BEAVRS baffle universes """
 
-        self.dummy = openmc.ZCylinder(name="Dummy filling universe", R=4000.)
+        self.dummy = openmc.ZCylinder(name="Dummy filling universe", r=4000.)
 
         # North Baffle
         self.u_baffle_N = openmc.Universe(name='Baffle North')

--- a/models/openmc/beavrs/constants.py
+++ b/models/openmc/beavrs/constants.py
@@ -153,7 +153,7 @@ rpvOR              =  241.300 # ML033530020
 
 neutronShieldIR    = 194.840 # ML033530020
 neutronShieldOR    = 201.630 # ML033530020
-neutronShield_NWbot_SEtop = {'A': 1, 'B': math.tan(math.pi/3 + math.pi/180), 'C': 0, 'D': 0}
-neutronShield_NWtop_SEbot = {'A': 1, 'B': math.tan(math.pi/6 - math.pi/180), 'C': 0, 'D': 0}
-neutronShield_NEbot_SWtop = {'A': 1, 'B': math.tan(-math.pi/3 - math.pi/180), 'C': 0, 'D': 0}
-neutronShield_NEtop_SWbot = {'A': 1, 'B': math.tan(-math.pi/6 + math.pi/180), 'C': 0, 'D': 0}
+neutronShield_NWbot_SEtop = {'a': 1, 'b': math.tan(math.pi/3 + math.pi/180), 'c': 0, 'd': 0}
+neutronShield_NWtop_SEbot = {'a': 1, 'b': math.tan(math.pi/6 - math.pi/180), 'c': 0, 'd': 0}
+neutronShield_NEbot_SWtop = {'a': 1, 'b': math.tan(-math.pi/3 - math.pi/180), 'c': 0, 'd': 0}
+neutronShield_NEtop_SWbot = {'a': 1, 'b': math.tan(-math.pi/6 + math.pi/180), 'c': 0, 'd': 0}

--- a/models/openmc/beavrs/corebuilder.py
+++ b/models/openmc/beavrs/corebuilder.py
@@ -250,13 +250,13 @@ class AxialPinCell(openmc.Universe):
         else:
             if isinstance(self.outermost.radii[-1], openmc.ZCylinder):
                 # current is a cylinder
-                current = self.outermost.radii[-1].coefficients['R']
+                current = self.outermost.radii[-1].coefficients['r']
             else:
                 # current is a box
                 current = self.outermost.radii[-1][-1]._surface.y0
             if isinstance(pincell.radii[-1], openmc.ZCylinder):
                 # new one is a cylinder
-                new = pincell.radii[-1].coefficients['R']
+                new = pincell.radii[-1].coefficients['r']
             else:
                 # new one is a box
                 new = self.outermost.radii[-1][-1]._surface.y0
@@ -346,4 +346,3 @@ class AxialPinCell(openmc.Universe):
         self.add_cell(cell)
 
         self.finalized = True
-

--- a/models/openmc/beavrs/pincells.py
+++ b/models/openmc/beavrs/pincells.py
@@ -49,13 +49,13 @@ class Pincells(object):
 
         # Rectangular prisms for grid spacers
         grid_surfs_tb = \
-            openmc.get_rectangular_prism(c.rodGridSide_tb, c.rodGridSide_tb)
+            openmc.rectangular_prism(c.rodGridSide_tb, c.rodGridSide_tb)
         grid_surfs_i = \
-            openmc.get_rectangular_prism(c.rodGridSide_i, c.rodGridSide_i)
+            openmc.rectangular_prism(c.rodGridSide_i, c.rodGridSide_i)
 
         # Rectangular prisms for lattice grid sleeves
         grid_surfs_ass = \
-            openmc.get_rectangular_prism(c.gridstrapSide, c.gridstrapSide)
+            openmc.rectangular_prism(c.gridstrapSide, c.gridstrapSide)
 
         # Grids axial surfaces
 
@@ -155,10 +155,10 @@ class Pincells(object):
 
         # Fuel radial surfaces
 
-        self.s_fuel_pellet_OR = openmc.ZCylinder(name='Fuel pellet OR', R=c.pelletOR)
-        self.s_fuel_clad_IR = openmc.ZCylinder(name='Fuel clad IR', R=c.cladIR)
-        self.s_fuel_clad_OR = openmc.ZCylinder(name='Fuel clad OR', R=c.cladOR)
-        self.s_fuel_plenumSpring_OR = openmc.ZCylinder(name='Fuel rod plenum spring OR', R=c.plenumSpringOR)
+        self.s_fuel_pellet_OR = openmc.ZCylinder(name='Fuel pellet OR', r=c.pelletOR)
+        self.s_fuel_clad_IR = openmc.ZCylinder(name='Fuel clad IR', r=c.cladIR)
+        self.s_fuel_clad_OR = openmc.ZCylinder(name='Fuel clad OR', r=c.cladOR)
+        self.s_fuel_plenumSpring_OR = openmc.ZCylinder(name='Fuel rod plenum spring OR', r=c.plenumSpringOR)
 
         # Fuel axial surfaces
 
@@ -210,10 +210,10 @@ class Pincells(object):
 
         # GT radial surfaces
 
-        self.s_gt_IR = openmc.ZCylinder(name='Guide tube IR', R=c.guideTubeIR)
-        self.s_gt_OR = openmc.ZCylinder(name='Guide tube OR', R=c.guideTubeOR)
-        self.s_gt_dashpot_IR = openmc.ZCylinder(name='Guide tube IR below dashpot', R=c.guideTubeDashIR)
-        self.s_gt_dashpot_OR = openmc.ZCylinder(name='Guide tube OR below dashpot', R=c.guideTubeDashOR)
+        self.s_gt_IR = openmc.ZCylinder(name='Guide tube IR', r=c.guideTubeIR)
+        self.s_gt_OR = openmc.ZCylinder(name='Guide tube OR', r=c.guideTubeOR)
+        self.s_gt_dashpot_IR = openmc.ZCylinder(name='Guide tube IR below dashpot', r=c.guideTubeDashIR)
+        self.s_gt_dashpot_OR = openmc.ZCylinder(name='Guide tube OR below dashpot', r=c.guideTubeDashOR)
 
         # GT axial surfaces
 
@@ -261,8 +261,8 @@ class Pincells(object):
 
         # IT radial surfaces
 
-        self.s_it_IR = openmc.ZCylinder(name='Instrument tube thimble IR', R=c.instrTubeIR)
-        self.s_it_OR = openmc.ZCylinder(name='Instrument tube thimble OR', R=c.instrTubeOR)
+        self.s_it_IR = openmc.ZCylinder(name='Instrument tube thimble IR', r=c.instrTubeIR)
+        self.s_it_OR = openmc.ZCylinder(name='Instrument tube thimble OR', r=c.instrTubeOR)
 
         # IT pincell universe
         self.u_it_p = InfinitePinCell(name='Instrument tube thimble')
@@ -294,12 +294,12 @@ class Pincells(object):
 
         # BP radial surfaces
 
-        self.s_bp_innerclad_IR = openmc.ZCylinder(name='BPRA rod radius 1', R=c.burnabs1)
-        self.s_bp_innerclad_OR = openmc.ZCylinder(name='BPRA rod radius 2', R=c.burnabs2)
-        self.s_bp_poison_IR = openmc.ZCylinder(name='BPRA rod radius 3', R=c.burnabs3)
-        self.s_bp_poison_OR = openmc.ZCylinder(name='BPRA rod radius 4', R=c.burnabs4)
-        self.s_bp_outerclad_IR = openmc.ZCylinder(name='BPRA rod radius 5', R=c.burnabs5)
-        self.s_bp_outerclad_OR = openmc.ZCylinder(name='BPRA rod radius 6', R=c.burnabs6)
+        self.s_bp_innerclad_IR = openmc.ZCylinder(name='BPRA rod radius 1', r=c.burnabs1)
+        self.s_bp_innerclad_OR = openmc.ZCylinder(name='BPRA rod radius 2', r=c.burnabs2)
+        self.s_bp_poison_IR = openmc.ZCylinder(name='BPRA rod radius 3', r=c.burnabs3)
+        self.s_bp_poison_OR = openmc.ZCylinder(name='BPRA rod radius 4', r=c.burnabs4)
+        self.s_bp_outerclad_IR = openmc.ZCylinder(name='BPRA rod radius 5', r=c.burnabs5)
+        self.s_bp_outerclad_OR = openmc.ZCylinder(name='BPRA rod radius 6', r=c.burnabs6)
 
         # BP axial surfaces
 
@@ -349,12 +349,12 @@ class Pincells(object):
 
         # RCCA rod radial surfaces
 
-        self.s_rcca_clad_IR = openmc.ZCylinder(name='RCCA rod clad IR', R=c.rcca_clad_IR)
-        self.s_rcca_clad_OR = openmc.ZCylinder(name='RCCA rod clad OR', R=c.rcca_clad_OR)
-        self.s_rcca_b4c_OR = openmc.ZCylinder(name='RCCA rod B4C OR', R=c.rcca_b4c_OR)
-        self.s_rcca_aic_OR = openmc.ZCylinder(name='RCCA rod AIC OR', R=c.rcca_aic_OR)
-        self.s_rcca_spacer_OR = openmc.ZCylinder(name='RCCA rod spacer OR', R=c.rcca_spacer_OR)
-        self.s_rcca_spring_OR = openmc.ZCylinder(name='RCCA rod plenum spring OR', R=c.rcca_spring_OR)
+        self.s_rcca_clad_IR = openmc.ZCylinder(name='RCCA rod clad IR', r=c.rcca_clad_IR)
+        self.s_rcca_clad_OR = openmc.ZCylinder(name='RCCA rod clad OR', r=c.rcca_clad_OR)
+        self.s_rcca_b4c_OR = openmc.ZCylinder(name='RCCA rod B4C OR', r=c.rcca_b4c_OR)
+        self.s_rcca_aic_OR = openmc.ZCylinder(name='RCCA rod AIC OR', r=c.rcca_aic_OR)
+        self.s_rcca_spacer_OR = openmc.ZCylinder(name='RCCA rod spacer OR', r=c.rcca_spacer_OR)
+        self.s_rcca_spring_OR = openmc.ZCylinder(name='RCCA rod plenum spring OR', r=c.rcca_spring_OR)
 
         # RCCA rod axial surfaces
 

--- a/models/openmc/beavrs/univzero.py
+++ b/models/openmc/beavrs/univzero.py
@@ -37,22 +37,22 @@ class UniverseZero(openmc.Universe):
 
         # RPV
 
-        self.s_RPVOR = openmc.ZCylinder(name='RPV OR', R=c.rpvOR, boundary_type='vacuum')
-        self.s_RPVIR = openmc.ZCylinder(name='RPV IR', R=c.rpvIR)
+        self.s_RPVOR = openmc.ZCylinder(name='RPV OR', r=c.rpvOR, boundary_type='vacuum')
+        self.s_RPVIR = openmc.ZCylinder(name='RPV IR', r=c.rpvIR)
         self.c_RPV = openmc.Cell(name="RPV", fill=self.mats['Carbon Steel'])
         self.c_RPV.region = (-self.s_RPVOR & +self.s_RPVIR &
                              -self.s_upperBound & +self.s_lowerBound)
 
         # RPV liner
 
-        self.s_linerIR = openmc.ZCylinder(name='RPV Liner IR', R=c.linerIR)
+        self.s_linerIR = openmc.ZCylinder(name='RPV Liner IR', r=c.linerIR)
         self.c_liner = openmc.Cell(name="RPV Liner", fill=self.mats['SS304'])
         self.c_liner.region = (-self.s_RPVIR & +self.s_linerIR &
                                -self.s_upperBound & +self.s_lowerBound)
 
         # Downcomer
 
-        self.s_neutronShieldOR = openmc.ZCylinder(name='Shield Panel OR', R=c.neutronShieldOR)
+        self.s_neutronShieldOR = openmc.ZCylinder(name='Shield Panel OR', r=c.neutronShieldOR)
         self.c_downcomer = openmc.Cell(name="Downcomer", fill=self.mats['Borated Water'])
         self.c_downcomer.region = (-self.s_linerIR & +self.s_neutronShieldOR &
                                -self.s_upperBound & +self.s_lowerBound)
@@ -62,7 +62,7 @@ class UniverseZero(openmc.Universe):
         """ Adds BEAVRS shield panels """
 
         # Shield panels
-        self.s_neutronShieldIR = openmc.ZCylinder(name='Shield Panel IR', R=c.neutronShieldIR)
+        self.s_neutronShieldIR = openmc.ZCylinder(name='Shield Panel IR', r=c.neutronShieldIR)
         self.s_ns_NWbot_SEtop = openmc.Plane(name='Shield Panel NWbot/SEtop', **c.neutronShield_NWbot_SEtop)
         self.s_ns_NWtop_SEbot = openmc.Plane(name='Shield Panel NWtop/SEbot', **c.neutronShield_NWtop_SEbot)
         self.s_ns_NEbot_SWtop = openmc.Plane(name='Shield Panel NEbot/SWtop', **c.neutronShield_NEbot_SWtop)
@@ -118,7 +118,7 @@ class UniverseZero(openmc.Universe):
                               -self.s_upperBound & +self.s_lowerBound)
         self.c_shieldPanels.append(self.c_sp_W)
 
-        self.s_coreBarrelOR = openmc.ZCylinder(name='Core Barrel OR', R=c.coreBarrelOR)
+        self.s_coreBarrelOR = openmc.ZCylinder(name='Core Barrel OR', r=c.coreBarrelOR)
         self.c_sp_inner = openmc.Cell(name='Water between barrel and shield', fill=self.mats['Borated Water'])
         self.c_sp_inner.region = (+self.s_coreBarrelOR & -self.s_neutronShieldIR &
                                   -self.s_upperBound & +self.s_lowerBound)
@@ -130,7 +130,7 @@ class UniverseZero(openmc.Universe):
 
         # Core barrel
 
-        self.s_coreBarrelIR = openmc.ZCylinder(name='Core Barrel IR', R=c.coreBarrelIR)
+        self.s_coreBarrelIR = openmc.ZCylinder(name='Core Barrel IR', r=c.coreBarrelIR)
         self.c_coreBarrel = openmc.Cell(name="Core Barrel", fill=self.mats['SS304'])
         self.c_coreBarrel.region = (-self.s_coreBarrelOR & +self.s_coreBarrelIR &
                                     -self.s_upperBound & +self.s_lowerBound)

--- a/models/openmc/extract-pin.ipynb
+++ b/models/openmc/extract-pin.ipynb
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "# Create surface as the boundary of clad and cell pitches\n",
-    "fuel_clad_OR = openmc.ZCylinder(name='Fuel clad OR', R=c.cladOR)\n",
+    "fuel_clad_OR = openmc.ZCylinder(name='Fuel clad OR', r=c.cladOR)\n",
     "pin_sides = openmc.model.get_rectangular_prism(c.pinPitch, c.pinPitch,\n",
     "                                               boundary_type='reflective')\n",
     "# Create a cell filled by the fuel pin\n",


### PR DESCRIPTION
This PR makes a few minor changes in the use of the OpenMC Python API to match what it currently expects, namely:

- The surface classes now take lowercase argument names (e.g., `r` instead of `R`)
- `get_rectangular_prism` is now `rectangular_prism`