### PR TITLE
RCCA Insertion Planes

### DIFF
--- a/models/openmc/beavrs/builder.py
+++ b/models/openmc/beavrs/builder.py
@@ -24,15 +24,13 @@ warnings.simplefilter('once', DeprecationWarning)
 class BEAVRS(object):
     """ Main BEAVRS class"""
 
-    def __init__(self, boron_ppm=c.nominalBoronPPM, is_symmetric=False, is_2d=False):
+    def __init__(self, boron_ppm=c.nominalBoronPPM, is_symmetric=False, is_2d=False, rcca_z = c.rcca_bank_steps_withdrawn_default):
         """ We build the entire geometry in memory in the constructor """
-
-        # TODO: make the control rod bank insertion heights attributes
 
         # Setup the materials
         self.mats = openmc_materials(ppm=boron_ppm)
 
-        self.pincells = Pincells(self.mats)
+        self.pincells = Pincells(self.mats, rcca_z)
         self.assemblies = Assemblies(self.pincells, self.mats)
         self.baffle = Baffle(self.assemblies, self.mats)
         self.core = Core(self.pincells, self.assemblies, self.baffle, is_symmetric=is_symmetric)

--- a/models/openmc/beavrs/constants.py
+++ b/models/openmc/beavrs/constants.py
@@ -13,7 +13,7 @@ rcca_bank_steps_withdrawn_default = {
     'A': 228,
     'B': 228,
     'C': 228,
-    'D':   0, # bite position is bank D at 213 steps withdrawn
+    'D': 213, # bite position is bank D at 213 steps withdrawn
     'SA': 228,
     'SB': 228,
     'SC': 228,

--- a/models/openmc/beavrs/constants.py
+++ b/models/openmc/beavrs/constants.py
@@ -9,7 +9,7 @@ nominalBoronPPM = 975
 ############## Geometry paramters ##############
 
 ## Steps withdrawn for each RCCA bank
-rcca_bank_steps_withdrawn = {
+rcca_bank_steps_withdrawn_default = {
     'A': 228,
     'B': 228,
     'C': 228,
@@ -20,7 +20,6 @@ rcca_bank_steps_withdrawn = {
     'SD': 228,
     'SE': 228,
 }
-rcca_banks = rcca_bank_steps_withdrawn.keys()
 
 ## pincell parameters
 pelletOR        = 0.39218  #

--- a/models/openmc/beavrs/pincells.py
+++ b/models/openmc/beavrs/pincells.py
@@ -13,10 +13,12 @@ from beavrs.corebuilder import AxialPinCell
 
 class Pincells(object):
 
-    def __init__(self, mats):
+    def __init__(self, mats, rcca_insertion_steps):
         """ Creates BEAVRS pincell universes """
 
         self.mats = mats
+
+        self.rcca_z = rcca_insertion_steps
 
         self._add_structural_axials()
         self._add_dummy_universe()
@@ -364,8 +366,8 @@ class Pincells(object):
         self.s_rcca_b4c_top = {}
         self.s_rcca_spacer_top = {}
         self.s_rcca_plenum_top = {}
-        for b in sorted(c.rcca_banks):
-            d = c.rcca_bank_steps_withdrawn[b]*c.rcca_StepWidth
+        for b in sorted(self.rcca_z.keys()):
+            d = self.rcca_z[b]*c.rcca_StepWidth
             self.s_rcca_rod_bot[b] = openmc.ZPlane(name='Bottom of RCCA rod bank {0}'.format(b), z0=c.rcca_Rod_bot + d)
             self.s_rcca_lowerFitting_top[b] = openmc.ZPlane(name='Top of RCCA rod lower fitting bank {0}'.format(b), z0=c.rcca_LowerFitting_top + d)
             self.s_rcca_aic_top[b] = openmc.ZPlane(name='Top of RCCA rod AIC bank {0}'.format(b), z0=c.rcca_AIC_top + d)
@@ -402,7 +404,7 @@ class Pincells(object):
         # RCCA rod axial stack
 
         self.u_rcca = {}
-        for b in sorted(c.rcca_banks):
+        for b in sorted(self.rcca_z):
             self.u_rcca[b] = AxialPinCell(name='RCCA bank {0}'.format(b))
             self.u_rcca[b].add_axial_section(self.s_struct_supportPlate_bot, self.mats['Borated Water'])
             self.u_rcca[b].add_axial_section(self.s_struct_lowerNozzle_top, self.mats['Water SPN'])

--- a/models/openmc/beavrs/pincells.py
+++ b/models/openmc/beavrs/pincells.py
@@ -366,7 +366,7 @@ class Pincells(object):
         self.s_rcca_b4c_top = {}
         self.s_rcca_spacer_top = {}
         self.s_rcca_plenum_top = {}
-        for b in sorted(self.rcca_z.keys()):
+        for b in sorted(self.rcca_z):
             d = self.rcca_z[b]*c.rcca_StepWidth
             self.s_rcca_rod_bot[b] = openmc.ZPlane(name='Bottom of RCCA rod bank {0}'.format(b), z0=c.rcca_Rod_bot + d)
             self.s_rcca_lowerFitting_top[b] = openmc.ZPlane(name='Top of RCCA rod lower fitting bank {0}'.format(b), z0=c.rcca_LowerFitting_top + d)
@@ -404,7 +404,7 @@ class Pincells(object):
         # RCCA rod axial stack
 
         self.u_rcca = {}
-        for b in sorted(self.rcca_z.keys()):
+        for b in sorted(self.rcca_z):
             self.u_rcca[b] = AxialPinCell(name='RCCA bank {0}'.format(b))
             self.u_rcca[b].add_axial_section(self.s_struct_supportPlate_bot, self.mats['Borated Water'])
             self.u_rcca[b].add_axial_section(self.s_struct_lowerNozzle_top, self.mats['Water SPN'])

--- a/models/openmc/beavrs/pincells.py
+++ b/models/openmc/beavrs/pincells.py
@@ -404,7 +404,7 @@ class Pincells(object):
         # RCCA rod axial stack
 
         self.u_rcca = {}
-        for b in sorted(self.rcca_z):
+        for b in sorted(self.rcca_z.keys()):
             self.u_rcca[b] = AxialPinCell(name='RCCA bank {0}'.format(b))
             self.u_rcca[b].add_axial_section(self.s_struct_supportPlate_bot, self.mats['Borated Water'])
             self.u_rcca[b].add_axial_section(self.s_struct_lowerNozzle_top, self.mats['Water SPN'])

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -22,7 +22,8 @@ p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                + ' are insertion steps (values).' \
                + ' Valid keys are \'A\', \'B\', \'C\', \'D\', \'SA\',' \
                + ' \'SB\', \'SC\', \'SD\', and \'SE\'. Valid values are' \
-               + ' integers between 0 and 228 (inclusive).')
+               + ' integers between 0 and 228 (inclusive). All banks default' \
+               + ' to fully withdrawn.')
 args = p.parse_args()
 
 insertions = c.rcca_bank_steps_withdrawn_default

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -19,12 +19,15 @@ p.add_option('-s', '--symmetric', action='store_true', dest='is_symmetric',
              default=False, help='Create octant-symmetric input files,' \
              + ' not symmetric by default')
 p.add_option('-z', '--rcca_d_z', dest='rcca_d_z',
-             help='The number of steps withdrawn for RCC bank D, 0 by default',
+             help='The number of steps withdrawn for RCCA bank D, 0 by default',
              type=int, default=0)
 (options, args) = p.parse_args()
 
 if not len(args) == 0:
     p.print_help()
+
+if options.rcca_d_z < 0 or options.rcca_d_z > 228:
+    raise Exception('The insertion step for RCCA bank D must be between 0 and 228!')
 
 insertions = c.rcca_bank_steps_withdrawn_default
 insertions['D'] = options.rcca_d_z

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -12,10 +12,10 @@ os.chdir('build')
 
 p = ArgumentParser()
 p.add_argument('-d', '--2d', action='store_true', dest='is_2d', default=False, \
-               help='Create 2D BEAVRS input files 3D by default')
+               help='Create 2D BEAVRS input files, 3D by default.')
 p.add_argument('-s', '--symmetric', action='store_true', dest='is_symmetric', \
                default=False, help='Create octant-symmetric input files,' \
-               + ' not symmetric by default')
+               + ' not symmetric by default.')
 p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                help='RCCA insertion steps, provided as key-value pairs,' \
                + ' where even arguments are banks (keys) and odd arguments'

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -2,6 +2,7 @@
 
 import os
 from beavrs.builder import BEAVRS
+import beavrs.constants as c
 from optparse import OptionParser
 
 try:
@@ -17,11 +18,17 @@ p.add_option('-d', '--2d', action='store_true', dest='is_2d',
 p.add_option('-s', '--symmetric', action='store_true', dest='is_symmetric',
              default=False, help='Create octant-symmetric input files,' \
              + ' not symmetric by default')
+p.add_option('-z', '--rcca_d_z', dest='rcca_d_z',
+             help='The number of steps withdrawn for RCC bank D, 0 by default',
+             type=int, default=0)
 (options, args) = p.parse_args()
 
 if not len(args) == 0:
     p.print_help()
 
-b = BEAVRS(is_symmetric=options.is_symmetric, is_2d=options.is_2d)
+insertions = c.rcca_bank_steps_withdrawn_default
+insertions['D'] = options.rcca_d_z
+
+b = BEAVRS(is_symmetric=options.is_symmetric, is_2d=options.is_2d, rcca_z=insertions)
 b.write_openmc_model()
 

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -23,7 +23,8 @@ p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                + ' Valid keys are \'A\', \'B\', \'C\', \'D\', \'SA\',' \
                + ' \'SB\', \'SC\', \'SD\', and \'SE\'. Valid values are' \
                + ' integers between 0 and 228 (inclusive). All banks default' \
-               + ' to fully withdrawn.')
+               + ' to fully withdrawn except for bank D, which is withdrawn to' \
+               + ' the bite position (step 213).')
 args = p.parse_args()
 
 insertions = c.rcca_bank_steps_withdrawn_default

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -3,35 +3,42 @@
 import os
 from beavrs.builder import BEAVRS
 import beavrs.constants as c
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 try:
     os.mkdir('build')
 except OSError: pass
 os.chdir('build')
 
-usage = """usage: %prog [options]"""
-p = OptionParser(usage=usage)
-p.add_option('-d', '--2d', action='store_true', dest='is_2d',
-             default=False, help='Create 2D BEAVRS input files,' \
-             + ' 3D by default')
-p.add_option('-s', '--symmetric', action='store_true', dest='is_symmetric',
-             default=False, help='Create octant-symmetric input files,' \
-             + ' not symmetric by default')
-p.add_option('-z', '--rcca_d_z', dest='rcca_d_z',
-             help='The number of steps withdrawn for RCCA bank D, 0 by default',
-             type=int, default=0)
-(options, args) = p.parse_args()
-
-if not len(args) == 0:
-    p.print_help()
-
-if options.rcca_d_z < 0 or options.rcca_d_z > 228:
-    raise Exception('The insertion step for RCCA bank D must be between 0 and 228!')
+p = ArgumentParser()
+p.add_argument('-d', '--2d', action='store_true', dest='is_2d', default=False, \
+               help='Create 2D BEAVRS input files 3D by default')
+p.add_argument('-s', '--symmetric', action='store_true', dest='is_symmetric', \
+               default=False, help='Create octant-symmetric input files,' \
+               + ' not symmetric by default')
+p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
+               help='RCCA insertion steps, provided as key-value pairs,' \
+               + ' where even arguments are banks (keys) and odd arguments'
+               + ' are insertion steps (values).' \
+               + ' Valid keys are \'A\', \'B\', \'C\', \'D\', \'SA\',' \
+               + ' \'SB\', \'SC\', \'SD\', and \'SE\'. Valid values are' \
+               + ' integers between 0 and 228 (inclusive).')
+args = p.parse_args()
 
 insertions = c.rcca_bank_steps_withdrawn_default
-insertions['D'] = options.rcca_d_z
 
-b = BEAVRS(is_symmetric=options.is_symmetric, is_2d=options.is_2d, rcca_z=insertions)
+# Error handle the RCCA insertion steps.
+rcca_args = dict(zip(args.rcca[::2], args.rcca[1::2]))
+for k in rcca_args:
+  if k not in insertions.keys():
+    raise Exception(f'{k} is not a valid RCCA bank! Valid options are \'A\',' + \
+                    ' \'B\', \'C\', \'D\', \'SA\', \'SB\', \'SC\', \'SD\', and \'SE\'.')
+  if rcca_args[k].isdigit() and (0 <= int(rcca_args[k]) and int(rcca_args[k]) <= 228):
+     insertions[k] = int(rcca_args[k])
+  else:
+     raise Exception(f'Invalid RCCA insertion step {rcca_args[k]}! Valid insertion' \
+                     + ' steps are integers between 0 and 228 (inclusive).')
+
+b = BEAVRS(is_symmetric=args.is_symmetric, is_2d=args.is_2d, rcca_z=insertions)
 b.write_openmc_model()
 


### PR DESCRIPTION
This brief PR makes a few changes which allow users to specify RCCA insertion planes in the constructor of the BEAVRS builder, alongside the addition of command line arguments to `make_beavrs.py` which allows the user to specify the insertion step for RCCA bank D.