### PR TITLE
Add a symmetric option for instrument tubes

### DIFF
--- a/models/openmc/beavrs/builder.py
+++ b/models/openmc/beavrs/builder.py
@@ -24,7 +24,8 @@ warnings.simplefilter('once', DeprecationWarning)
 class BEAVRS(object):
     """ Main BEAVRS class"""
 
-    def __init__(self, boron_ppm=c.nominalBoronPPM, is_symmetric=False, is_2d=False, rcca_z = c.rcca_bank_steps_withdrawn_default):
+    def __init__(self, boron_ppm=c.nominalBoronPPM, is_symmetric=False, is_2d=False, rcca_z = c.rcca_bank_steps_withdrawn_default, \
+                 instrument_per_assembly=False):
         """ We build the entire geometry in memory in the constructor """
 
         # Setup the materials
@@ -33,7 +34,7 @@ class BEAVRS(object):
         self.pincells = Pincells(self.mats, rcca_z)
         self.assemblies = Assemblies(self.pincells, self.mats)
         self.baffle = Baffle(self.assemblies, self.mats)
-        self.core = Core(self.pincells, self.assemblies, self.baffle, is_symmetric=is_symmetric)
+        self.core = Core(self.pincells, self.assemblies, self.baffle, is_symmetric=is_symmetric, instrument_per_assembly=instrument_per_assembly)
         self.main_universe = UniverseZero(self.core, self.mats, is_2d=is_2d)
 
         self.openmc_geometry = openmc.Geometry(self.main_universe)

--- a/models/openmc/beavrs/core.py
+++ b/models/openmc/beavrs/core.py
@@ -57,13 +57,19 @@ class Core(object):
         'J___1', 'J___2', 'J___3', 'J___8', 'J___9', 'K__15', 'K__14', 'K__13',
         'K__12', 'K__11', 'K__10']
 
-    def __init__(self, pincells, assemblies, baffle, is_symmetric=False):
+    def __init__(self, pincells, assemblies, baffle, is_symmetric=False, instrument_per_assembly=False):
         """ Creates BEAVRS core lattice universe """
 
         self.pins = pincells
         self.assem = assemblies
         self.baffle = baffle
         self.is_symmetric = is_symmetric
+        # Whether a instrument tube per assembly should be used
+        # instead of placing instrument tubes in measured assemblies.
+        # This has a fairly large impact on k due to displacement of
+        # borated water, however it makes generating flux maps possible
+        # for 1/4 and 1/8 core models. Use with caution!
+        self.instrument_per_assembly = instrument_per_assembly
 
         self._set_enrichment_positions()
         self._set_instrument_tube_positions()
@@ -176,7 +182,7 @@ class Core(object):
             if self.is_symmetric:
                 instr = 'no instr'
             else:
-                if pos in self.instr_positions:
+                if pos in self.instr_positions or self.instrument_per_assembly:
                     instr = 'instr'
                 else:
                     instr = 'no instr'

--- a/models/openmc/beavrs/core.py
+++ b/models/openmc/beavrs/core.py
@@ -64,11 +64,11 @@ class Core(object):
         self.assem = assemblies
         self.baffle = baffle
         self.is_symmetric = is_symmetric
-        # Whether a instrument tube per assembly should be used
+        # Whether an instrument tube per assembly should be used
         # instead of placing instrument tubes in measured assemblies.
-        # This has a fairly large impact on k due to displacement of
-        # borated water, however it makes generating flux maps possible
-        # for 1/4 and 1/8 core models. Use with caution!
+        # This has an small impact on k due to displacement of borated
+        # water, however it makes generating flux maps easier for 1/4
+        # and 1/8 core models.
         self.instrument_per_assembly = instrument_per_assembly
 
         self._set_enrichment_positions()

--- a/models/openmc/beavrs/core.py
+++ b/models/openmc/beavrs/core.py
@@ -180,9 +180,12 @@ class Core(object):
             else:
                 ba = 'no BAs'
             if self.is_symmetric:
-                instr = 'no instr'
+                if not self.instrument_per_assembly:
+                  instr = 'no instr'
+                else:
+                  instr = 'instr'
             else:
-                if pos in self.instr_positions or self.instrument_per_assembly:
+                if pos in self.instr_positions:
                     instr = 'instr'
                 else:
                     instr = 'no instr'

--- a/models/openmc/beavrs/core.py
+++ b/models/openmc/beavrs/core.py
@@ -64,8 +64,8 @@ class Core(object):
         self.assem = assemblies
         self.baffle = baffle
         self.is_symmetric = is_symmetric
-        # Whether an instrument tube per assembly should be used
-        # instead of placing instrument tubes in measured assemblies.
+        # Whether an instrument tube should be placed in the center pin
+        # position of each assembly instead of an empty guide tube.
         # This has an small impact on k due to displacement of borated
         # water, however it makes generating flux maps easier for 1/4
         # and 1/8 core models.

--- a/models/openmc/beavrs/materials.py
+++ b/models/openmc/beavrs/materials.py
@@ -104,6 +104,15 @@ def openmc_materials(ppm):
 # Create special materials
 ##############################################
 
+########## Air in the instrument thimble #################
+    mats['Air TH'] = openmc.Material(name='Air TH')
+    mats['Air TH'].set_density('g/cc', 0.000616)
+    mats['Air TH'].add_element('O', 0.2095, 'ao')
+    mats['Air TH'].add_element('N', 0.7809, 'ao')
+    mats['Air TH'].add_element('Ar', 0.00933, 'ao')
+    mats['Air TH'].add_element('C', 0.00027, 'ao')
+    mats['Air TH'].add_nuclide('U235', 1e-8, 'ao')
+
 ########## Enriched UO2 Fuel #################
 
     # Specify enrichments to be calculated

--- a/models/openmc/beavrs/pincells.py
+++ b/models/openmc/beavrs/pincells.py
@@ -268,7 +268,7 @@ class Pincells(object):
 
         # IT pincell universe
         self.u_it_p = InfinitePinCell(name='Instrument tube thimble')
-        self.u_it_p.add_ring(self.mats['Air'], self.s_it_IR)
+        self.u_it_p.add_ring(self.mats['Air TH'], self.s_it_IR)
         self.u_it_p.add_last_ring(self.mats['Zircaloy 4'])
         self.u_it_p.finalize()
 

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -19,9 +19,8 @@ p.add_argument('-s', '--symmetric', action='store_true', dest='is_symmetric', \
 p.add_argument('-i', '--sym-instrument', action='store_true', dest='sym_instrument', \
                default=False, help='Add instrument tubes to all assemblies in an ' \
                + 'octant-symmetric input file (only valid if the model is symmetric).' \
-               + 'Defaults to not adding instrument tubes per-assembly. This makes it '
-               + 'easier to generate full-core flux maps at the cost of displacing ' \
-               + 'boronated water.')
+               + 'This makes it easier to generate full-core fission rate maps at the ' \
+               + 'cost of displacing boronated water.')
 p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                help='RCCA insertion steps, provided as key-value pairs,' \
                + ' where even arguments are banks (keys) and odd arguments'
@@ -37,7 +36,7 @@ args = p.parse_args()
 # configuration.
 if not args.is_symmetric and args.sym_instrument:
    raise Exception('Instrument tubes per assembly can only be used with an ' \
-                   + 'octant-symmetric configuration.')
+                   + 'octant-symmetric configuration. -i must be used with -s!')
 
 insertions = c.rcca_bank_steps_withdrawn_default
 

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -21,7 +21,7 @@ p.add_argument('-i', '--sym-instrument', action='store_true', dest='sym_instrume
                + 'octant-symmetric input file (only valid if the model is symmetric).' \
                + 'Defaults to not adding instrument tubes per-assembly. This makes it '
                + 'easier to generate full-core flux maps at the cost of displacing ' \
-               + 'boronated water. Use with caution.')
+               + 'boronated water.')
 p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                help='RCCA insertion steps, provided as key-value pairs,' \
                + ' where even arguments are banks (keys) and odd arguments'
@@ -32,6 +32,12 @@ p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                + ' to fully withdrawn except for bank D, which is withdrawn to' \
                + ' the bite position (step 213).')
 args = p.parse_args()
+
+# Error if the user wants instrument tubes per assembly in a non-symmetric core
+# configuration.
+if not args.is_symmetric and args.sym_instrument:
+   raise Exception('Instrument tubes per assembly can only be used with an ' \
+                   + 'octant-symmetric configuration.')
 
 insertions = c.rcca_bank_steps_withdrawn_default
 

--- a/models/openmc/make_beavrs.py
+++ b/models/openmc/make_beavrs.py
@@ -16,6 +16,12 @@ p.add_argument('-d', '--2d', action='store_true', dest='is_2d', default=False, \
 p.add_argument('-s', '--symmetric', action='store_true', dest='is_symmetric', \
                default=False, help='Create octant-symmetric input files,' \
                + ' not symmetric by default.')
+p.add_argument('-i', '--sym-instrument', action='store_true', dest='sym_instrument', \
+               default=False, help='Add instrument tubes to all assemblies in an ' \
+               + 'octant-symmetric input file (only valid if the model is symmetric).' \
+               + 'Defaults to not adding instrument tubes per-assembly. This makes it '
+               + 'easier to generate full-core flux maps at the cost of displacing ' \
+               + 'boronated water. Use with caution.')
 p.add_argument("--rcca-insertion", dest='rcca', nargs='*', default='', \
                help='RCCA insertion steps, provided as key-value pairs,' \
                + ' where even arguments are banks (keys) and odd arguments'
@@ -41,6 +47,7 @@ for k in rcca_args:
      raise Exception(f'Invalid RCCA insertion step {rcca_args[k]}! Valid insertion' \
                      + ' steps are integers between 0 and 228 (inclusive).')
 
-b = BEAVRS(is_symmetric=args.is_symmetric, is_2d=args.is_2d, rcca_z=insertions)
+b = BEAVRS(is_symmetric=args.is_symmetric, is_2d=args.is_2d, rcca_z=insertions, \
+           instrument_per_assembly=args.sym_instrument)
 b.write_openmc_model()
 


### PR DESCRIPTION
This PR adds a separate air material for instrument tubes with a trace amount of U-235 to make it easier to generate HZP flux maps. It also adds an option to the OpenMC BEAVRS builder (and associated subclasses) to add instrument tubes to all assemblies (instead of the asymmetric instrument tube loading). This makes it easier to generate the eighth core HZP flux maps at the cost of displacing boronated water (which has a small impact on criticality).

Symmetric with instrument tubes in each assembly:
```
Combined k-effective = 1.00028 +/- 0.00029
```
Symmetric without instrument tubes in each assembly
```
 Combined k-effective = 1.00002 +/- 0.00028
```
(10,000 particles per batch, 100 inactive batches, 900 active batches).